### PR TITLE
chore: move vue-router to devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,13 +23,13 @@
     "better-auth": "0.7.6-beta.2",
     "nuxt": "^3.14.159",
     "ofetch": "^1.4.1",
-    "vue": "^3.5.12",
-    "vue-router": "^4.4.5"
+    "vue": "^3.5.12"
   },
   "devDependencies": {
     "@nuxt/eslint-config": "^0.6.1",
     "eslint": "^9.14.0",
     "typescript": "^5.6.3",
+    "vue-router": "^4.4.5",
     "vue-tsc": "^2.1.10",
     "wrangler": "^3.85.0"
   },


### PR DESCRIPTION
The use of `vue-router` is just for types, therefore is it necessary as runtime dependency?